### PR TITLE
SDK on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "postversion": "git push && git push --tags",
     "test": "mocha --compilers js:babel-core/register -r babel-polyfill -s 100 --recursive test/index test",
     "test:watch": "mocha -w --compilers js:babel-core/register -r babel-polyfill -s 100 --recursive test/index test",
-    "transpile": "BABEL_ENV=production babel --no-comments --out-dir dist src"
+    "transpile": "babel --no-comments --out-dir dist src"
   },
   "dependencies": {
     "es6-promise": "4.1.0",


### PR DESCRIPTION
#### Description
Part of MLIBZ-1958.

#### Changes
Removed the setting of BABEL_ENV environment variables from the build command line since the syntax for this is different on Windows and it is being set by the .env file anyways.
